### PR TITLE
feat: report preview is now rendered using the correct template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
-        "getkirby/cms": "3.6.0-rc.4"
+        "getkirby/cms": "3.6.0-rc.4",
+        "mockery/mockery": "^1.4"
     },
     "scripts": {
         "test": "phpunit --bootstrap tests/bootstrap.php tests"

--- a/composer.lock
+++ b/composer.lock
@@ -1,20 +1,20 @@
 {
-    "_readme": [
-        "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-        "This file is @generated automatically"
-    ],
-    "content-hash": "f668811a9bcc1ed7d5fd7c3ab05b8b0c",
-    "packages": [
-        {
-            "name": "getkirby/composer-installer",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/getkirby/composer-installer.git",
-                "reference": "c98ece30bfba45be7ce457e1102d1b169d922f3d"
-            },
-            "dist": {
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "44f74f3b9d6dacec3353e26303292427",
+  "packages": [
+    {
+      "name": "getkirby/composer-installer",
+      "version": "1.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/getkirby/composer-installer.git",
+        "reference": "c98ece30bfba45be7ce457e1102d1b169d922f3d"
+      },
+      "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/getkirby/composer-installer/zipball/c98ece30bfba45be7ce457e1102d1b169d922f3d",
                 "reference": "c98ece30bfba45be7ce457e1102d1b169d922f3d",
@@ -959,25 +959,76 @@
                 "issues": "https://github.com/getkirby/kirby/issues",
                 "source": "https://github.com/getkirby/kirby"
             },
-            "funding": [
-                {
-                    "url": "https://getkirby.com/buy",
-                    "type": "custom"
-                }
-            ],
-            "time": "2021-11-05T14:42:21+00:00"
+          "funding": [
+            {
+              "url": "https://getkirby.com/buy",
+              "type": "custom"
+            }
+          ],
+          "time": "2021-11-05T14:42:21+00:00"
         },
-        {
-            "name": "laminas/laminas-escaper",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+      {
+        "name": "hamcrest/hamcrest-php",
+        "version": "v2.0.1",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/hamcrest/hamcrest-php.git",
+          "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+          "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+          "shasum": ""
+        },
+        "require": {
+          "php": "^5.3|^7.0|^8.0"
+        },
+        "replace": {
+          "cordoval/hamcrest-php": "*",
+          "davedevelopment/hamcrest-php": "*",
+          "kodova/hamcrest-php": "*"
+        },
+        "require-dev": {
+          "phpunit/php-file-iterator": "^1.4 || ^2.0",
+          "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+        },
+        "type": "library",
+        "extra": {
+          "branch-alias": {
+            "dev-master": "2.1-dev"
+          }
+        },
+        "autoload": {
+          "classmap": [
+            "hamcrest"
+          ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+          "BSD-3-Clause"
+        ],
+        "description": "This is the PHP port of Hamcrest Matchers",
+        "keywords": [
+          "test"
+        ],
+        "support": {
+          "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+          "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+        },
+        "time": "2020-07-09T08:09:16+00:00"
+      },
+      {
+        "name": "laminas/laminas-escaper",
+        "version": "2.9.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/laminas/laminas-escaper.git",
+          "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
                 "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
                 "shasum": ""
             },
@@ -1132,26 +1183,98 @@
                 "dashes",
                 "quotes",
                 "spaces",
-                "typographer",
-                "typography"
+              "typographer",
+              "typography"
             ],
-            "support": {
-                "issues": "https://github.com/michelf/php-smartypants/issues",
-                "source": "https://github.com/michelf/php-smartypants/tree/1.8.1"
-            },
-            "time": "2016-12-13T01:01:17+00:00"
+          "support": {
+            "issues": "https://github.com/michelf/php-smartypants/issues",
+            "source": "https://github.com/michelf/php-smartypants/tree/1.8.1"
+          },
+          "time": "2016-12-13T01:01:17+00:00"
         },
-        {
-            "name": "mustangostang/spyc",
-            "version": "0.6.3",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:mustangostang/spyc.git",
-                "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/4627c838b16550b666d15aeae1e5289dd5b77da0",
+      {
+        "name": "mockery/mockery",
+        "version": "1.4.4",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/mockery/mockery.git",
+          "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/mockery/mockery/zipball/e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
+          "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
+          "shasum": ""
+        },
+        "require": {
+          "hamcrest/hamcrest-php": "^2.0.1",
+          "lib-pcre": ">=7.0",
+          "php": "^7.3 || ^8.0"
+        },
+        "conflict": {
+          "phpunit/phpunit": "<8.0"
+        },
+        "require-dev": {
+          "phpunit/phpunit": "^8.5 || ^9.3"
+        },
+        "type": "library",
+        "extra": {
+          "branch-alias": {
+            "dev-master": "1.4.x-dev"
+          }
+        },
+        "autoload": {
+          "psr-0": {
+            "Mockery": "library/"
+          }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+          "BSD-3-Clause"
+        ],
+        "authors": [
+          {
+            "name": "Pádraic Brady",
+            "email": "padraic.brady@gmail.com",
+            "homepage": "http://blog.astrumfutura.com"
+          },
+          {
+            "name": "Dave Marshall",
+            "email": "dave.marshall@atstsolutions.co.uk",
+            "homepage": "http://davedevelopment.co.uk"
+          }
+        ],
+        "description": "Mockery is a simple yet flexible PHP mock object framework",
+        "homepage": "https://github.com/mockery/mockery",
+        "keywords": [
+          "BDD",
+          "TDD",
+          "library",
+          "mock",
+          "mock objects",
+          "mockery",
+          "stub",
+          "test",
+          "test double",
+          "testing"
+        ],
+        "support": {
+          "issues": "https://github.com/mockery/mockery/issues",
+          "source": "https://github.com/mockery/mockery/tree/1.4.4"
+        },
+        "time": "2021-09-13T15:28:59+00:00"
+      },
+      {
+        "name": "mustangostang/spyc",
+        "version": "0.6.3",
+        "source": {
+          "type": "git",
+          "url": "git@github.com:mustangostang/spyc.git",
+          "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/mustangostang/spyc/zipball/4627c838b16550b666d15aeae1e5289dd5b77da0",
                 "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0",
                 "shasum": ""
             },

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ use Kirby\Cms\Blueprint;
 use Kirby\Cms\Response;
 use KirbyReporter\Model\FormData;
 use KirbyReporter\Report\ReportClient;
+use KirbyReporter\Report\ReportMailTemplateParser;
 use KirbyReporter\Report\ReportTemplateParser;
 use KirbyReporter\Vendor\IssueTracker;
 use KirbyReporter\Vendor\Mail;
@@ -96,10 +97,16 @@ Kirby::plugin('gearsdigital/reporter-for-kirby', [
                 'action' => function () {
                     $requestData = kirby()->request()->body()->data();
                     $formData = new FormData($requestData);
-                    if (isset($formData->getFormFields()['description'])) {
+                    if (is_array(option('gearsdigital.reporter-for-kirby.repository'))) {
                         $parsedTemplate = (new class {
                             use ReportTemplateParser;
-                        })->parseTemplate($formData->getFormFields());
+                        })->parseTemplate($formData);
+
+                        return new Response(json_encode(trim($parsedTemplate)), 'application/json');
+                    } elseif ($type = option('gearsdigital.reporter-for-kirby.mail.type')) {
+                        $parsedTemplate = (new class {
+                            use ReportMailTemplateParser;
+                        })->parseTemplate($formData, $type ?? 'text');
 
                         return new Response(json_encode(trim($parsedTemplate)), 'application/json');
                     }

--- a/lib/Report/ReportClient.php
+++ b/lib/Report/ReportClient.php
@@ -53,6 +53,6 @@ class ReportClient
 
         // we need to parse the reporer template first because we need to send a plain 'string'
         // to external APIs
-        return $this->client->report($formData, $this->parseTemplate($formData->getFormFields()));
+        return $this->client->report($formData, $this->parseTemplate($formData));
     }
 }

--- a/lib/Report/ReportMailTemplateParser.php
+++ b/lib/Report/ReportMailTemplateParser.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KirbyReporter\Report;
+
+use Kirby\Toolkit\Tpl;
+use KirbyReporter\Model\FormData;
+
+trait ReportMailTemplateParser
+{
+    private string $pluginName = 'gearsdigital/reporter-for-kirby';
+
+    public function parseTemplate(FormData $formData, string $type): string
+    {
+        return Tpl::load($this->getReportTemplate($type), ['title' => $formData->getTitle(), 'fields' => $formData->getFormFields()]);
+    }
+
+    private function getReportTemplate(string $type): string
+    {
+        $template = "report.${type}.php";
+        $templateRoot = kirby()->root('templates').DS."emails";
+        $pluginRoot = kirby()->plugin($this->pluginName);
+        $templatePath = file_exists($templateRoot.DS.$template) ? $templateRoot : $pluginRoot->root().DS."templates/emails";
+
+        return $templatePath.DS."$template";
+    }
+}

--- a/lib/Report/ReportTemplateParser.php
+++ b/lib/Report/ReportTemplateParser.php
@@ -3,14 +3,15 @@
 namespace KirbyReporter\Report;
 
 use Kirby\Toolkit\Tpl;
+use KirbyReporter\Model\FormData;
 
 trait ReportTemplateParser
 {
     private string $pluginName = 'gearsdigital/reporter-for-kirby';
 
-    public function parseTemplate(array $templateData): string
+    public function parseTemplate(FormData $formData): string
     {
-        return Tpl::load($this->getReportTemplate(), ['fields' => $templateData]);
+        return Tpl::load($this->getReportTemplate(), ['title' => $formData->getTitle(), 'fields' => $formData->getFormFields()]);
     }
 
     private function getReportTemplate(): string

--- a/templates/emails/report.html.php
+++ b/templates/emails/report.html.php
@@ -1,7 +1,7 @@
 Issue Report from "<?= site()->title() ?? ''; ?>" by <?= kirby()->user()->nameOrEmail() ?? ''; ?>
 
 ---
-<?= $title ?? ''; ?>
+<b><?= $title ?? ''; ?></b>
 
 ---
 <?= $fields['description'] ?? ''; ?>

--- a/tests/Traits/ReportMailTemplateParserTest.php
+++ b/tests/Traits/ReportMailTemplateParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace KirbyReporter\Traits;
+
+use Kirby\Toolkit\Tpl;
+use KirbyReporter\Model\FormData;
+use KirbyReporter\Report\ReportMailTemplateParser;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class ReportMailTemplateParserTest extends MockeryTestCase
+{
+
+    private array $formData = [
+        'title' => 'Lorem',
+        'formFields' => [
+            'description' => 'Test',
+        ],
+    ];
+
+    public function test_parse_report_mail_text_template(): void
+    {
+        $mock = Mockery::mock('alias:'.Tpl::class);
+        $mock->shouldReceive('load')->andReturn('my-loaded-text-template');
+
+        $formData = new FormData($this->formData);
+        $parser = $this->getObjectForTrait(ReportMailTemplateParser::class);
+        $parsedTemplate = $parser->parseTemplate($formData, 'text');
+
+        $this->assertTrue(is_string($parsedTemplate));
+        $this->assertEquals('my-loaded-text-template', $parsedTemplate);
+    }
+
+    public function test_parse_report_mail_html_template(): void
+    {
+        $mock = Mockery::mock('alias:'.Tpl::class);
+        $mock->shouldReceive('load')->andReturn('my-loaded-html-template');
+
+        $formData = new FormData($this->formData);
+        $parser = $this->getObjectForTrait(ReportMailTemplateParser::class);
+        $parsedTemplate = $parser->parseTemplate($formData, 'html');
+
+        $this->assertTrue(is_string($parsedTemplate));
+        $this->assertEquals('my-loaded-html-template', $parsedTemplate);
+    }
+
+}

--- a/tests/Traits/ReportTemplateParserTest.php
+++ b/tests/Traits/ReportTemplateParserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace KirbyReporter\Traits;
+
+use Kirby\Toolkit\Tpl;
+use KirbyReporter\Model\FormData;
+use KirbyReporter\Report\ReportTemplateParser;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class ReportTemplateParserTest extends MockeryTestCase
+{
+    private array $formData = [
+        'title' => 'Lorem',
+        'formFields' => [
+            'description' => 'Test',
+        ],
+    ];
+
+    public function test_parse_reporter_template(): void
+    {
+        $mock = Mockery::mock('alias:'.Tpl::class);
+        $mock->shouldReceive('load')->andReturn('my-loaded-template');
+
+        $formData = new FormData($this->formData);
+        $parser = $this->getObjectForTrait(ReportTemplateParser::class);
+        $parsedTemplate = $parser->parseTemplate($formData);
+
+        $this->assertTrue(is_string($parsedTemplate));
+        $this->assertEquals('my-loaded-template', $parsedTemplate);
+    }
+}


### PR DESCRIPTION
This MR fixes the issue that always the report template is used even if a user had configured email as report type.

#### Type: `text`
If report email type is set to text, the email-text-template is rendered.

#### Type: `html`
If report email type is set to html, the email-html-template is rendered - but the HTML isn't parsed which allows the User to preview the markup. That might change in the future.

Closes #45